### PR TITLE
Fix geometrycollection Import

### DIFF
--- a/xplan_reader.py
+++ b/xplan_reader.py
@@ -161,6 +161,17 @@ class XplanReader:
             self.group_extent = QgsRectangle()
 
             driver = ogr.GetDriverByName('GML')
+            driver.Open(my_gml)
+
+            # change GeometryType in gfs to handle GeometryCollection import 
+            my_gfs = os.path.splitext(my_gml)[0] + '.gfs'
+            gfs_tree = etree.parse(my_gfs)
+            gfs_root = gfs_tree.getroot()
+            for geometry_type in gfs_root.iter('GeometryType'):
+                if geometry_type.text == '7':
+                    geometry_type.text = '0'
+            gfs_tree.write(my_gfs, encoding = "UTF-8", xml_declaration = False)
+
             layers = [l.GetName() for l in driver.Open(my_gml)]
 
             def addXplanLayer(layername, gtype):

--- a/xplan_reader.py
+++ b/xplan_reader.py
@@ -162,16 +162,22 @@ class XplanReader:
             self.group_extent = QgsRectangle()
 
             driver = ogr.GetDriverByName('GML')
-            driver.Open(my_gml)
 
-            # change GeometryType in gfs to handle GeometryCollection import 
             my_gfs = os.path.splitext(my_gml)[0] + '.gfs'
-            gfs_tree = etree.parse(my_gfs)
-            gfs_root = gfs_tree.getroot()
-            for geometry_type in gfs_root.iter('GeometryType'):
-                if geometry_type.text == '7':
-                    geometry_type.text = '0'
-            gfs_tree.write(my_gfs, encoding = "UTF-8", xml_declaration = False)
+
+            # don't touch existing .gfs
+            if not os.path.isfile(my_gfs):
+                write_gfs = False
+                driver.Open(my_gml)
+                gfs_tree = etree.parse(my_gfs)
+                gfs_root = gfs_tree.getroot()
+                for geometry_type in gfs_root.iter('GeometryType'):
+                    # if needed, change GeometryType in .gfs to handle GeometryCollection import
+                    if geometry_type.text == '7':
+                        geometry_type.text = '0'
+                        write_gfs = True
+                if write_gfs:
+                    gfs_tree.write(my_gfs, encoding = "UTF-8", xml_declaration = False)
 
             layers = [l.GetName() for l in driver.Open(my_gml)]
 


### PR DESCRIPTION
Fixes #1

Passe vom GML-Treiber automatisch erzeugte GFS an.

Mögliche Alternative wäre die Verwendung von GFS-Templates, siehe https://github.com/kreis-viersen/xplan-reader/issues/3 .